### PR TITLE
Added variable flag for switching on/off warnings about unknown URDF tags

### DIFF
--- a/cl_urdf/src/parser.lisp
+++ b/cl_urdf/src/parser.lisp
@@ -30,6 +30,8 @@
 
 (in-package :cl-urdf)
 
+(defparameter *display-ignored-warning* nil)
+
 (define-condition urdf-type-not-supported (simple-warning) ())
 (define-condition urdf-attribute-not-supported (simple-warning) ())
 (define-condition urdf-malformed (simple-error) ())
@@ -37,9 +39,10 @@
 (defgeneric parse-xml-node (name node &optional robot)
   (:method (name node &optional robot)
     (declare (ignore node robot))
-    (warn 'urdf-type-not-supported
-          :format-control "URDF element type `~a' not supported. Ignoring it."
-          :format-arguments (list name))))
+    (when *display-ignored-warning*
+      (warn 'urdf-type-not-supported
+            :format-control "URDF element type `~a' not supported. Ignoring it."
+            :format-arguments (list name)))))
 
 (defun read-fields (str)
   "Returns a list of space-separated fields in `str'. This function uses


### PR DESCRIPTION
Allows to switch on/off the tedious warning about URDF tags which `cl-urdf` doesn't understand (and ignores).

Turned off by default.