### PR TITLE
roslisp-utils: in STARTUP-ROS added a call to SHUTDOWN-ROS if node is already running

### DIFF
--- a/roslisp_utilities/src/ros-node.lisp
+++ b/roslisp_utilities/src/ros-node.lisp
@@ -48,6 +48,8 @@
                     (cmd-line-args nil cmds-supplied-p?)
                     (name "cram_hl")
                     (anonymous t))
+  (when (eql roslisp::*node-status* :running)
+    (shutdown-ros))
   (if master-uri?
       (if cmds-supplied-p?
     	    (start-ros-node name :anonymous anonymous :master-uri master-uri :cmd-line-args cmd-line-args)


### PR DESCRIPTION
if there is a running node STARTUP-ROS will actually restart the node, not start it from scratch, in that case, call the cleanup functions before starting anew.