### PR TITLE
cl_trans_stamped: in conditions renamed DESCRIPTION to ERROR-DESCRIPTION

### DIFF
--- a/cl_transforms_stamped/src/conditions.lisp
+++ b/cl_transforms_stamped/src/conditions.lisp
@@ -30,10 +30,10 @@
 (in-package :cl-transforms-stamped)
 
 (define-condition transform-stamped-error (error)
-  ((description :initarg :description :reader description))
+  ((description :initarg :description :reader error-description))
   (:documentation "A base class for all transform stamped conditions")
   (:report (lambda (condition stream)
-             (format stream (description condition)))))
+             (format stream (error-description condition)))))
 
 (define-condition connectivity-error (transform-stamped-error) ()
   (:documentation "The frames requested are not connected in the reference frame tree"))

--- a/cl_transforms_stamped/src/package.lisp
+++ b/cl_transforms_stamped/src/package.lisp
@@ -21,7 +21,7 @@
               ;; conditions
               transform-stamped-error connectivity-error lookup-error
               extrapolation-error invalid-argument-error timeout-error
-              description
+              error-description
               ;; utilities.lisp
               unslash-frame resolve-frame
               ,@(let ((r nil))


### PR DESCRIPTION
otherwise it is too generic and conflicts with other packages.