### PR TITLE
cl-tf: strip leading slash in frames before storing them (and looking them up)

### DIFF
--- a/cl_tf/src/transformer.lisp
+++ b/cl_tf/src/transformer.lisp
@@ -292,7 +292,7 @@ TARGET-TIME or FIXED-FRAME arguments."))
 (defun ensure-fully-qualified-name (frame-id &optional (tf-prefix ""))
   "Makes sure that the first character in `frame-id' is set to `tf-prefix'"
   (declare (type string frame-id tf-prefix))
-  (concatenate 'string tf-prefix frame-id))
+  (unslash-frame (concatenate 'string tf-prefix frame-id)))
 
 (defun ensure-null-time (time)
   "Makes sure that time is NIL if it is either NIL or 0"


### PR DESCRIPTION
TF implementation in C++ (both TF1 and TF2) is currently stripping the leading slash before storing it:
https://github.com/ros/geometry2/blob/indigo-devel/tf2/src/buffer_core.cpp#L210

When looking up TF2 throws an error:
https://github.com/ros/geometry2/blob/indigo-devel/tf2/src/buffer_core.cpp#L591
and TF1 strips the leading slash:
https://github.com/ros/geometry/blob/indigo-devel/tf/src/tf.cpp#L242

In `cl-tf` we have the same function that ensures the TF frame name is valid before storing and before looking up. As this is a TF1 implementation which is supposed to be relaxed about the "/" issue (according to the corresponding C++ implementation) I suggest the Lisp implementation should also just always strip the slash.