### PR TITLE
[roslisp_utilities] Added lisp <-> ros naming conversions

### DIFF
--- a/roslisp_utilities/src/lispification.lisp
+++ b/roslisp_utilities/src/lispification.lisp
@@ -71,8 +71,7 @@
 
 (defun rosify-underscores-lisp-name (lispy-symbol)
   (declare (type symbol lispy-symbol))
-  "Returns a string where all dashes are substituted with underscores.
-Taken from cram_json_prolog PROLOGIFY function"
+  "Returns a string where all dashes are substituted with underscores."
   (flet ((contains-lower-case-char (symbol)
            (and
             (find-if (lambda (ch)

--- a/roslisp_utilities/src/lispification.lisp
+++ b/roslisp_utilities/src/lispification.lisp
@@ -62,3 +62,25 @@
                     (princ (char-upcase ch) strm)
                     (princ (char-downcase ch) strm))
                 (setf upcase nil)))))
+
+(defun lispify-ros-underscore-name (ros-string &optional package)
+  (declare (type string ros-string))
+  "Returns a lispified symbol replacing all underscores with dashes."
+  (intern (string-upcase (substitute #\- #\_ ros-string))
+          (or package *package*)))
+
+(defun rosify-underscores-lisp-name (lispy-symbol)
+  (declare (type symbol lispy-symbol))
+  "Returns a string where all dashes are substituted with underscores.
+Taken from cram_json_prolog PROLOGIFY function"
+  (flet ((contains-lower-case-char (symbol)
+           (and
+            (find-if (lambda (ch)
+                       (let ((lch (char-downcase ch)))
+                         (and (find lch "abcdefghijklmnopqrstuvwxyz")
+                              (eq lch ch))))
+                     (symbol-name symbol))
+            t)))
+    (if (contains-lower-case-char lispy-symbol)
+        (string lispy-symbol)
+        (string-downcase (substitute #\_ #\- (copy-seq (string lispy-symbol)))))))

--- a/roslisp_utilities/src/package.lisp
+++ b/roslisp_utilities/src/package.lisp
@@ -37,4 +37,6 @@
            #:startup-ros
            #:shutdown-ros
            #:lispify-ros-name
-           #:rosify-lisp-name))
+           #:rosify-lisp-name
+           #:lispify-ros-underscore-name
+           #:rosify-underscores-lisp-name))


### PR DESCRIPTION
Functions for replacing underscores with dashes and the other way around.