### PR TITLE
In cl-tf2 check for null pointer

### DIFF
--- a/cl_tf2/src/buffer-client.lisp
+++ b/cl_tf2/src/buffer-client.lisp
@@ -69,7 +69,7 @@
              (status
                (send-goal-and-wait action-client goal-msg timeout timeout))
              (result (result action-client)))
-        (unless (eq status :succeeded)
+        (unless (and result (eq status :succeeded))
           (error 'transform-stamped-error :description
                  (if result
                      (roslisp:msg-slot-value (roslisp:msg-slot-value result :error) :error_string)


### PR DESCRIPTION
Sometimes when tf2 query is not successful the result is NIL, make sure to check for it.