### PR TITLE
Add URDF support for multiple visual and collision elements of a link

### DIFF
--- a/cl_urdf/src/link.lisp
+++ b/cl_urdf/src/link.lisp
@@ -89,9 +89,12 @@
               link with its children")
    (name :reader name :initarg :name)
    (intertial :reader inertial :initarg :inertial)
-   (visual :reader visual :initarg :visual)
-   ;; URDF supports mutiple collision entries per link.
-   ;; Keep single collision for backwards compatibility.
+   ;; URDF supports mutiple entries of visual and collision per link.
+   ;; Keep single visual and collision for backwards compatibility.
+   (visual :reader visual :initarg :visual
+           :documentation "The first visual element of this link.")
+   (visuals :reader visuals :initarg :visuals
+            :documentation "List of all visual elements of this link.")
    (collision :reader collision :initarg :collision
               :documentation "The first collision element of this link.")
    (collisions :reader collisions :initarg :collisions

--- a/cl_urdf/src/link.lisp
+++ b/cl_urdf/src/link.lisp
@@ -90,5 +90,10 @@
    (name :reader name :initarg :name)
    (intertial :reader inertial :initarg :inertial)
    (visual :reader visual :initarg :visual)
-   (collision :reader collision :initarg :collision)))
+   ;; URDF supports mutiple collision entries per link.
+   ;; Keep single collision for backwards compatibility.
+   (collision :reader collision :initarg :collision
+              :documentation "The first collision element of this link.")
+   (collisions :reader collisions :initarg :collisions
+               :documentation "List of all collision elements of this link.")))
 

--- a/cl_urdf/src/link.lisp
+++ b/cl_urdf/src/link.lisp
@@ -89,7 +89,7 @@
               link with its children")
    (name :reader name :initarg :name)
    (intertial :reader inertial :initarg :inertial)
-   ;; URDF supports mutiple entries of visual and collision per link.
+   ;; URDF supports multiple entries of visual and collision per link.
    ;; Keep single visual and collision for backwards compatibility.
    (visual :reader visual :initarg :visual
            :documentation "The first visual element of this link.")

--- a/cl_urdf/src/package.lisp
+++ b/cl_urdf/src/package.lisp
@@ -39,7 +39,7 @@
    geometry box size cylinder radius length cylinder-length sphere
    mesh filename scale
    material color texture
-   visual
+   visual visuals
    collision collisions
    link from-joint to-joints
    robot links joints root-link materials

--- a/cl_urdf/src/package.lisp
+++ b/cl_urdf/src/package.lisp
@@ -40,7 +40,7 @@
    mesh filename scale
    material color texture
    visual
-   collision
+   collision collisions
    link from-joint to-joints
    robot links joints root-link materials
    urdf-type-not-supported urdf-attribute-not-supported urdf-malformed

--- a/cl_urdf/src/parser.lisp
+++ b/cl_urdf/src/parser.lisp
@@ -135,6 +135,7 @@
 (defmethod parse-xml-node ((name (eql :|link|)) node &optional robot)
   (let ((inertial (xml-element-child node :|inertial|))
         (visual (xml-element-child node :|visual|))
+        (visuals (xml-element-children-list node :|visual|))
         (collision (xml-element-child node :|collision|))
         (collisions (xml-element-children-list node :|collision|)))
     (make-instance
@@ -144,6 +145,10 @@
                  (parse-xml-node :|inertial| inertial robot))
      :visual (when visual
                (parse-xml-node :|visual| visual robot))
+     :visuals (when visuals
+                (mapcar (lambda (visual)
+                          (parse-xml-node :|visual| visual robot))
+                        visuals))
      :collision (when collision
                   (parse-xml-node :|collision| collision robot))
      :collisions (when collisions


### PR DESCRIPTION
Links in URDF can have multiple `visual` and `collision` children (http://wiki.ros.org/urdf/XML/link).
Parsing some URDF link with `cl_urdf` always took the first child.  

This PR adds two fields to the `cl-urdf:link` class: `visuals` and `collisions`. It keeps the old fields untouched for backwards-compatibility. When an XML link is parsed, all node children are filtered for the `:|visual|`/`:|collision|` name, and set as a list to their respective slot in the `cl-urdf:link` instance.

Test this with a URDF from the parameter server:
```lisp
(cl-urdf:parse-urdf
           (roslisp:get-param "robot_description"))
```